### PR TITLE
Initial support for event namespace isolation

### DIFF
--- a/lib/logstash/plugin_mixins/event_support.rb
+++ b/lib/logstash/plugin_mixins/event_support.rb
@@ -1,0 +1,79 @@
+require 'logstash/namespace'
+require 'logstash/event'
+
+require 'logstash/plugin_mixins/event_support/event_factory'
+require 'logstash/plugin_mixins/event_support/event_target_decorator'
+
+module LogStash
+  module PluginMixins
+    module EventSupport
+
+      def event_factory
+        @_event_factory ||=
+          if ecs_compatibility?
+            EventFactory::INSTANCE
+          else
+            LegacyEventFactory::INSTANCE
+          end
+      end
+
+      def event_factory=(factory)
+        @_event_factory = factory
+      end
+
+      # Creates a new event using the set event factory.
+      # @param target_namespace an optional namespace (prefix) for data in event
+      # @param event_factory
+      # @return [LogStash::Event]
+      def new_event(data = {}, target_namespace: nil, event_factory: self.event_factory)
+        return event_factory.new_event(data) unless target_namespace
+
+        # NOTE: might be more performant to create event using all data and use move_event_data helper
+        init_data = data.select { |key, _| key.start_with?('@') || key.start_with?('[@') } # @timestamp, [@metadata][foo]
+        event = event_factory.new_event(init_data)
+        target = '[' + target_namespace.split(/\[(.*)\]/).join + ']'
+        data.slice(*(data.keys - init_data.keys)).each do |key, val|
+          key = "[#{key}]" unless key.index('[')
+          event.set(target + key, val)
+        end
+        event
+      end
+
+      private
+
+      def with_namespace(event, target_namespace)
+        if target_namespace.nil? || target_namespace.empty?
+          yield event
+        else
+          yield EventTargetDecorator.wrap(event, target_namespace)
+        end
+      end
+
+      # Move all event data under given namespace (prefix).
+      #
+      # All field mappings, except for internal keys such as @timestamp and @metadata,
+      # will be moved under a target namespace e.g.
+      #
+      #   'foo' => 'bar'  ->  '[target][foo]' => 'bar'
+      #
+      # @note The passed event gets modified in place.
+      def move_event_data(event, target_namespace)
+        return if target_namespace.nil? || target_namespace.empty?
+
+        event_data = event.to_hash
+
+        empty_proto = LogStash::Event.new '@timestamp' => event.timestamp
+        empty_proto.cancel if event.cancelled?
+        event_data.reject! do |key, val|
+          if key.start_with?('@')
+            empty_proto.set(key, val) || true
+          end
+        end
+
+        event.overwrite(empty_proto)
+        event.set(target_namespace, event_data)
+      end
+
+    end
+  end
+end

--- a/lib/logstash/plugin_mixins/event_support/event_factory.rb
+++ b/lib/logstash/plugin_mixins/event_support/event_factory.rb
@@ -1,0 +1,42 @@
+require 'logstash/event'
+
+module LogStash; module PluginMixins; module EventSupport
+
+  class EventFactory
+
+    INSTANCE = new
+
+    def new_event(data = {})
+      event = LogStash::Event.new(data)
+      normalize(event, data)
+      event
+    end
+
+    def normalize(event, data = nil)
+      return if event.include?('event.created')
+
+      if data.nil? || data['@timestamp']
+        created = LogStash::Timestamp.now
+      else
+        created = event.timestamp
+      end
+      event.set('event.created', created)
+    end
+
+  end
+
+  class LegacyEventFactory
+
+    INSTANCE = new
+
+    def new_event(data = {})
+      LogStash::Event.new(data)
+    end
+
+    def normalize(event, data = nil)
+      # no-op
+    end
+
+  end
+
+end end end

--- a/lib/logstash/plugin_mixins/event_support/event_target_decorator.rb
+++ b/lib/logstash/plugin_mixins/event_support/event_target_decorator.rb
@@ -1,0 +1,116 @@
+require 'logstash/event'
+require 'forwardable'
+
+module LogStash; module PluginMixins; module EventSupport
+
+  # `LogStash::Event` decorator which supports most of the event API.
+  # Values end up being stored in a (prefix hash) target namespace.
+  #
+  # @note Internal references (starting with `@`) e.g. `@timestamp` or
+  # `@metadata` are respected and thus are NOT namespaced.
+  class EventTargetDecorator
+    extend Forwardable
+
+    def self.wrap(event, target_namespace = nil)
+      self.new(event, target_namespace)
+    end
+
+    def initialize(event, target_namespace)
+      @event = event
+      namespace = target_namespace.to_s.strip
+      if namespace.empty? || namespace.start_with?('[')
+        @target_ns = namespace
+      else
+        @target_ns = "[#{namespace}]"
+      end
+    end
+
+    # Event interface
+
+    def_delegators :@event, :cancel, :uncancel, :cancelled?, :clone # no args
+    def_delegators :@event, :to_s, :to_hash, :to_hash_with_metadata, :to_json
+    def_delegators :@event, :tag, :timestamp, :timestamp=
+
+    # @return value at [target_namespace][ref]
+    #
+    # @note Internal references @timestamp and @metadata are NOT namespaced.
+    def get(ref)
+      @event.get(target_ref(ref))
+    end
+
+    # @return set value
+    #
+    # @note Internal references @timestamp and @metadata are NOT namespaced.
+    def set(ref, value)
+      @event.set(target_ref(ref), value)
+    end
+
+    # @return whether reference is present in event
+    #
+    # @note Internal references @timestamp and @metadata are NOT namespaced.
+    def include?(ref)
+      @event.include?(target_ref(ref))
+    end
+
+    # Removes a mapping from the event.
+    #
+    # @note Internal references @timestamp and @metadata are NOT namespaced.
+    def remove(ref)
+      @event.remove(target_ref(ref))
+    end
+
+    # Appends data from given event to this event.
+    # @return self
+    def append(event)
+      if @target_ns.empty?
+        namespaced_event = event
+      else
+        namespaced_event = LogStash::Event.new
+        namespaced_event.set @target_ns, event.to_hash
+      end
+      @event.append(namespaced_event) # only data is appended
+      self
+    end
+
+    # Overwrite event from another.
+    # @return self
+    #
+    # @note In this case target namespace is not maintained.
+    def overwrite(event)
+      # TODO unclear whether we really need this to retain namespace when overwriting, might be confusing?!?
+      @event.overwrite(event)
+      self
+    end
+
+    # @note Not supported due the difficulty of arbitrary reference resolution.
+    def sprintf(format)
+      raise NotImplementedError.new("#{self.class} does not support Event#sprintf")
+    end
+
+    # Custom
+
+    def __unwrap__
+      @event
+    end
+    alias unwrap __unwrap__
+
+    private
+
+    def target_ref(ref)
+      ref = ref.to_str
+      return ref if internal_ref?(ref)
+
+      if ref.start_with?('[')
+        @target_ns + ref
+      else
+        "#{@target_ns}[#{ref}]"
+      end
+    end
+
+    def internal_ref?(ref)
+      ref.start_with?('@') || ref.start_with?('[@')
+    end
+
+  end
+
+end end end

--- a/spec/logstash/core/legacy_ruby_event_spec.rb
+++ b/spec/logstash/core/legacy_ruby_event_spec.rb
@@ -1,0 +1,580 @@
+require File.expand_path('../../spec_helper.rb', __FILE__)
+require 'time'
+require 'json'
+
+describe LogStash::Event do
+
+  shared_examples 'namespace-able event' do
+
+    context "[]=" do
+      it "should raise an exception if you attempt to set @timestamp to a value type other than a Time object" do
+        expect{subject.set("@timestamp", "crash!")}.to raise_error(TypeError)
+      end
+
+      it "should assign simple fields" do
+        expect(subject.get("foo")).to be nil
+        expect(subject.set("foo", "bar")).to eq("bar")
+        expect(subject.get("foo")).to eq("bar")
+      end
+
+      it "should overwrite simple fields" do
+        expect(subject.get("foo")).to be nil
+        expect(subject.set("foo", "bar")).to eq("bar")
+        expect(subject.get("foo")).to eq("bar")
+
+        expect(subject.set("foo", "baz")).to eq("baz")
+        expect(subject.get("foo")).to eq("baz")
+      end
+
+      it "should assign deep fields" do
+        expect(subject.get("[foo][bar]")).to be nil
+        expect(subject.set("[foo][bar]", "baz")).to eq("baz")
+        expect(subject.get("[foo][bar]")).to eq("baz")
+      end
+
+      it "should overwrite deep fields" do
+        expect(subject.get("[foo][bar]")).to be nil
+        expect(subject.set("[foo][bar]", "baz")).to eq("baz")
+        expect(subject.get("[foo][bar]")).to eq("baz")
+
+        expect(subject.set("[foo][bar]", "zab")).to eq("zab")
+        expect(subject.get("[foo][bar]")).to eq("zab")
+      end
+
+      it "allow to set the @metadata key to a hash" do
+        subject.set("@metadata", { "action" => "index" })
+        expect(subject.get("[@metadata][action]")).to eq("index")
+      end
+
+      it "should set nil element within existing array value" do
+        subject.set("[foo]", ["bar", "baz"])
+
+        expect(subject.set("[foo][0]", nil)).to eq(nil)
+        expect(subject.get("[foo]")).to eq([nil, "baz"])
+      end
+
+      it "should set nil in first element within empty array" do
+        subject.set("[foo]", [])
+
+        expect(subject.set("[foo][0]", nil)).to eq(nil)
+        expect(subject.get("[foo]")).to eq([nil])
+      end
+
+      it "should set nil in second element within empty array" do
+        subject.set("[foo]", [])
+
+        expect(subject.set("[foo][1]", nil)).to eq(nil)
+        expect(subject.get("[foo]")).to eq([nil, nil])
+      end
+    end
+
+    context "#[]" do
+      it "should fetch data" do
+        expect(subject.get("type")).to eq("sprintf")
+      end
+
+      it "should fetch fields" do
+        expect(subject.get("a")).to eq("b")
+        expect(subject.get('c')['d']).to eq("f")
+      end
+
+      it "should fetch deep fields" do
+        expect(subject.get("[j][k1]")).to eq("v")
+        expect(subject.get("[c][d]")).to eq("f")
+        expect(subject.get('[f][g][h]')).to eq("i")
+        expect(subject.get('[j][k3][4]')).to eq("m")
+        expect(subject.get('[j][5]')).to eq(7)
+      end
+    end
+
+    context "#include?" do
+      it "should include existing fields" do
+        expect(subject.include?("c")).to eq(true)
+        expect(subject.include?("[c][d]")).to eq(true)
+        expect(subject.include?("[j][k4][0][nested]")).to eq(true)
+      end
+
+      it "should include field with nil value" do
+        expect(subject.include?("nilfield")).to eq(true)
+      end
+
+      it "should include @metadata field" do
+        expect(subject.include?("@metadata")).to eq(true)
+      end
+
+      it "should include field within @metadata" do
+        expect(subject.include?("[@metadata][fancy]")).to eq(true)
+      end
+
+      it "should not include non-existing fields" do
+        expect(subject.include?("doesnotexist")).to eq(false)
+        expect(subject.include?("[j][doesnotexist]")).to eq(false)
+        expect(subject.include?("[tag][0][hello][yes]")).to eq(false)
+      end
+
+      it "should include within arrays" do
+        expect(subject.include?("[tags][0]")).to eq(true)
+        expect(subject.include?("[tags][1]")).to eq(false)
+      end
+    end
+
+    context "#append" do
+
+      it "should append strings to an array" do
+        subject.append(LogStash::Event.new("message" => "another thing"))
+        expect(subject.get("message")).to eq([ "hello world", "another thing" ])
+      end
+
+      it "should concatenate tags" do
+        subject.append(LogStash::Event.new("tags" => [ "tag2" ]))
+        # added to_a for when array is a Java Collection when produced from json input
+        expect(subject.get("tags").to_a).to eq([ "tag1", "tag2" ])
+      end
+
+      context "when event field is nil" do
+        it "should add single value as string" do
+          subject.append(LogStash::Event.new({"field1" => "append1"}))
+          expect(subject.get("field1")).to eq("append1")
+        end
+        it "should add multi values as array" do
+          subject.append(LogStash::Event.new({"field1" => [ "append1","append2" ]}))
+          expect(subject.get("field1")).to eq([ "append1","append2" ])
+        end
+      end
+
+      context "when event field is a string" do
+        before { subject.set("field1", "original1") }
+
+        it "should append string to values, if different from current" do
+          subject.append(LogStash::Event.new({"field1" => "append1"}))
+          expect(subject.get("field1")).to eq([ "original1", "append1" ])
+        end
+        it "should not change value, if appended value is equal current" do
+          subject.append(LogStash::Event.new({"field1" => "original1"}))
+          expect(subject.get("field1")).to eq("original1")
+        end
+        it "should concatenate values in an array" do
+          subject.append(LogStash::Event.new({"field1" => [ "append1" ]}))
+          expect(subject.get("field1")).to eq([ "original1", "append1" ])
+        end
+        it "should join array, removing duplicates" do
+          subject.append(LogStash::Event.new({"field1" => [ "append1","original1" ]}))
+          expect(subject.get("field1")).to eq([ "original1", "append1" ])
+        end
+      end
+
+      context "when event field is an array" do
+        before { subject.set("field1", [ "original1", "original2" ] )}
+
+        it "should append string values to array, if not present in array" do
+          subject.append(LogStash::Event.new({"field1" => "append1"}))
+          expect(subject.get("field1")).to eq([ "original1", "original2", "append1" ])
+        end
+        it "should not append string values, if the array already contains it" do
+          subject.append(LogStash::Event.new({"field1" => "original1"}))
+          expect(subject.get("field1")).to eq([ "original1", "original2" ])
+        end
+        it "should join array, removing duplicates" do
+          subject.append(LogStash::Event.new({"field1" => [ "append1","original1" ]}))
+          expect(subject.get("field1")).to eq([ "original1", "original2", "append1" ])
+        end
+      end
+
+    end
+
+    context "timestamp initialization" do
+      it "should coerce timestamp" do
+        t = Time.iso8601("2014-06-12T00:12:17.114Z")
+        expect(LogStash::Event.new("@timestamp" => t).timestamp.to_i).to eq(t.to_i)
+        expect(LogStash::Event.new("@timestamp" => LogStash::Timestamp.new(t)).timestamp.to_i).to eq(t.to_i)
+        expect(LogStash::Event.new("@timestamp" => "2014-06-12T00:12:17.114Z").timestamp.to_i).to eq(t.to_i)
+      end
+
+      it "should assign current time when no timestamp" do
+        expect(LogStash::Event.new({}).timestamp.to_i).to be_within(2).of (Time.now.to_i)
+      end
+
+      it "should tag for invalid value" do
+        event = wrap LogStash::Event.new("@timestamp" => "foo")
+        expect(event.timestamp.to_i).to be_within(2).of Time.now.to_i
+        expect(event.get("tags")).to eq([LogStash::Event::TIMESTAMP_FAILURE_TAG])
+        expect(event.get(LogStash::Event::TIMESTAMP_FAILURE_FIELD)).to eq("foo")
+
+        event = wrap LogStash::Event.new("@timestamp" => 666)
+        expect(event.timestamp.to_i).to be_within(2).of Time.now.to_i
+        expect(event.get("tags")).to eq([LogStash::Event::TIMESTAMP_FAILURE_TAG])
+        expect(event.get(LogStash::Event::TIMESTAMP_FAILURE_FIELD)).to eq(666)
+      end
+
+      it "should tag for invalid string format" do
+        event = wrap LogStash::Event.new("@timestamp" => "foo")
+        expect(event.timestamp.to_i).to be_within(2).of Time.now.to_i
+        expect(event.get("tags")).to eq([LogStash::Event::TIMESTAMP_FAILURE_TAG])
+        expect(event.get(LogStash::Event::TIMESTAMP_FAILURE_FIELD)).to eq("foo")
+      end
+    end
+
+    context "to_json" do
+      it "should support to_json" do
+        new_event = wrap LogStash::Event.new(
+            "@timestamp" => Time.iso8601("2014-09-23T19:26:15.832Z"),
+            "message" => "foo bar",
+            )
+        json = new_event.to_json
+
+        expect(JSON.parse(json)).to eq( JSON.parse("{\"@timestamp\":\"2014-09-23T19:26:15.832Z\",\"message\":\"foo bar\",\"@version\":\"1\"}"))
+      end
+
+      it "should support to_json and ignore arguments" do
+        new_event = wrap LogStash::Event.new(
+            "@timestamp" => Time.iso8601("2014-09-23T19:26:15.832Z"),
+            "message" => "foo bar",
+            )
+        json = new_event.to_json(:foo => 1, :bar => "baz")
+
+        expect(JSON.parse(json)).to eq( JSON.parse("{\"@timestamp\":\"2014-09-23T19:26:15.832Z\",\"message\":\"foo bar\",\"@version\":\"1\"}"))
+      end
+    end
+
+    context "metadata" do
+      context "with existing metadata" do
+        subject { wrap LogStash::Event.new("hello" => "world", "@metadata" => { "fancy" => "pants" }) }
+
+        it "should not include metadata in to_hash" do
+          expect(subject.to_hash.keys).not_to include("@metadata")
+
+          # 'hello', '@timestamp', and '@version'
+          expect(subject.to_hash.keys.count).to eq(3)
+        end
+
+        it "should still allow normal field access" do
+          expect(subject.get("hello")).to eq("world")
+        end
+      end
+
+      context "with set metadata" do
+        let(:fieldref) { "[@metadata][foo][bar]" }
+        let(:value) { "bar" }
+        subject { wrap LogStash::Event.new("normal" => "normal") }
+
+        before do
+          # Verify the test is configured correctly.
+          expect(fieldref).to start_with("[@metadata]")
+
+          # Set it.
+          subject.set(fieldref, value)
+        end
+
+        it "should still allow normal field access" do
+          expect(subject.get("normal")).to eq("normal")
+        end
+
+        it "should allow getting" do
+          expect(subject.get(fieldref)).to eq(value)
+        end
+
+        it "should be hidden from .to_json" do
+          obj = JSON.parse(subject.to_json)
+          expect(obj).not_to include("@metadata")
+        end
+
+        it "should be hidden from .to_hash" do
+          expect(subject.to_hash).not_to include("@metadata")
+        end
+
+        it "should be accessible through #to_hash_with_metadata" do
+          obj = subject.to_hash_with_metadata
+          expect(obj).to include("@metadata")
+          expect(obj["@metadata"]["foo"]["bar"]).to eq(value)
+        end
+      end
+
+      context "with no metadata" do
+        subject { wrap LogStash::Event.new("foo" => "bar") }
+
+        it "should have no metadata" do
+          expect(subject.get("@metadata")).to be_empty
+        end
+        it "should still allow normal field access" do
+          expect(subject.get("foo")).to eq("bar")
+        end
+
+        it "should not include the @metadata key" do
+          expect(subject.to_hash_with_metadata).not_to include("@metadata")
+        end
+      end
+    end
+
+    context "#to_s" do
+      let(:timestamp) { LogStash::Timestamp.new }
+      let(:event) { LogStash::Event.new({ "@timestamp" => timestamp, "host" => "foo", "message" => "bar" }) }
+      subject { wrap event }
+
+      it "return the string containing the timestamp, the host and the message" do
+        expect(subject.to_s).to eq("#{timestamp.to_iso8601} #{event.get("host")} #{event.get("message")}")
+      end
+    end
+
+    context "caching" do
+      let(:event) { wrap LogStash::Event.new({ "message" => "foo" }) }
+
+      it "should invalidate target caching" do
+        expect(event.get("[a][0]")).to be nil
+
+        expect(event.set("[a][0]", 42)).to eq(42)
+        expect(event.get("[a][0]")).to eq(42)
+        expect(event.get("[a]")).to eq({"0" => 42})
+
+        expect(event.set("[a]", [42, 24])).to eq([42, 24])
+        expect(event.get("[a]")).to eq([42, 24])
+
+        expect(event.get("[a][0]")).to eq(42)
+
+        expect(event.set("[a]", [24, 42])).to eq([24, 42])
+        expect(event.get("[a][0]")).to eq(24)
+
+        expect(event.set("[a][0]", {"a "=> 99, "b" => 98})).to eq({"a "=> 99, "b" => 98})
+        expect(event.get("[a][0]")).to eq({"a "=> 99, "b" => 98})
+
+        expect(event.get("[a]")).to eq([{"a "=> 99, "b" => 98}, 42])
+        expect(event.get("[a][0]")).to eq({"a "=> 99, "b" => 98})
+        expect(event.get("[a][1]")).to eq(42)
+        expect(event.get("[a][0][b]")).to eq(98)
+      end
+    end
+
+  end
+
+  shared_examples 'plain old event' do
+
+    # context "#sprintf" do
+    #
+    #   it "should report a unix timestamp for %{+%s}" do
+    #     expect(subject.sprintf("%{+%s}")).to eq("1356998400")
+    #   end
+    #
+    #   it "should work if there is no fieldref in the string" do
+    #     expect(subject.sprintf("bonjour")).to eq("bonjour")
+    #   end
+    #
+    #   it "should not raise error and should format as empty string when @timestamp field is missing" do
+    #     str = "hello-%{+%s}"
+    #     subj = subject.clone
+    #     subj.remove("[@timestamp]")
+    #     expect{ subj.sprintf(str) }.not_to raise_error # LogStash::Error
+    #     expect(subj.sprintf(str)).to eq("hello-")
+    #   end
+    #
+    #   it "should report a time with %{+format} syntax" do
+    #     expect(subject.sprintf("%{+yyyy}")).to eq("2013")
+    #     expect(subject.sprintf("%{+MM}")).to eq("01")
+    #     expect(subject.sprintf("%{+HH}")).to eq("00")
+    #   end
+    #
+    #   it "should support mixed string" do
+    #     expect(subject.sprintf("foo %{+YYYY-MM-dd} %{type}")).to eq("foo 2013-01-01 sprintf")
+    #   end
+    #
+    #   it "should not raise error with %{+format} syntax when @timestamp field is missing" do
+    #     str = "logstash-%{+yyyy}"
+    #     subj = subject.clone
+    #     subj.remove("[@timestamp]")
+    #     expect{ subj.sprintf(str) }.not_to raise_error # LogStash::Error
+    #   end
+    #
+    #   it "should report fields with %{field} syntax" do
+    #     expect(subject.sprintf("%{type}")).to eq("sprintf")
+    #     expect(subject.sprintf("%{message}")).to eq(subject.get("message"))
+    #   end
+    #
+    #   it "should print deep fields" do
+    #     expect(subject.sprintf("%{[j][k1]}")).to eq("v")
+    #     expect(subject.sprintf("%{[j][k2][0]}")).to eq("w")
+    #   end
+    #
+    #   it "should be able to take a non-string for the format" do
+    #     expect(subject.sprintf(2)).to eq("2")
+    #   end
+    #
+    #   it "should allow to use the metadata when calling #sprintf" do
+    #     expect(subject.sprintf("super-%{[@metadata][fancy]}")).to eq("super-pants")
+    #   end
+    #
+    #   it "should allow to use nested hash from the metadata field" do
+    #     expect(subject.sprintf("%{[@metadata][have-to-go][deeper]}")).to eq("inception")
+    #   end
+    #
+    #   it "should return a json string if the key is a hash" do
+    #     expect(subject.sprintf("%{[j][k3]}")).to eq("{\"4\":\"m\"}")
+    #   end
+    #
+    #   it "should not strip last character" do
+    #     expect(subject.sprintf("%{type}%{message}|")).to eq("sprintfhello world|")
+    #   end
+    #
+    #   it "should render nil array values as leading empty string" do
+    #     expect(subject.set("foo", [nil, "baz"])).to eq([nil, "baz"])
+    #
+    #     expect(subject.get("[foo][0]")).to be_nil
+    #     expect(subject.get("[foo][1]")).to eq("baz")
+    #
+    #     expect(subject.sprintf("%{[foo]}")).to eq(",baz")
+    #   end
+    #
+    #   it "should render nil array values as middle empty string" do
+    #     expect(subject.set("foo", ["bar", nil, "baz"])).to eq(["bar", nil, "baz"])
+    #
+    #     expect(subject.get("[foo][0]")).to eq("bar")
+    #     expect(subject.get("[foo][1]")).to be_nil
+    #     expect(subject.get("[foo][2]")).to eq("baz")
+    #
+    #     expect(subject.sprintf("%{[foo]}")).to eq("bar,,baz")
+    #   end
+    #
+    #   it "should render nil array values as trailing empty string" do
+    #     expect(subject.set("foo", ["bar", nil])).to eq(["bar", nil])
+    #
+    #     expect(subject.get("[foo][0]")).to eq("bar")
+    #     expect(subject.get("[foo][1]")).to be_nil
+    #
+    #     expect(subject.sprintf("%{[foo]}")).to eq("bar,")
+    #   end
+    #
+    #   it "should render deep arrays with nil value" do
+    #     subject.set("[foo]", [[12, nil], 56])
+    #     expect(subject.sprintf("%{[foo]}")).to eq("12,,56")
+    #   end
+    #
+    # end
+
+    # context "acceptable @timestamp formats" do
+    #   formats = [
+    #       "YYYY-MM-dd'T'HH:mm:ss.SSSZ",
+    #       "YYYY-MM-dd'T'HH:mm:ss.SSSSSSZ",
+    #       "YYYY-MM-dd'T'HH:mm:ss.SSS",
+    #       "YYYY-MM-dd'T'HH:mm:ss",
+    #       "YYYY-MM-dd'T'HH:mm:ssZ",
+    #   ]
+    #   formats.each do |format|
+    #     it "includes #{format}" do
+    #       time = subject.sprintf("%{+#{format}}")
+    #       begin
+    #         LogStash::Event.new("@timestamp" => time)
+    #       rescue => e
+    #         raise StandardError, "Time '#{time}' was rejected. #{e.class}: #{e.to_s}"
+    #       end
+    #     end
+    #   end
+    # end
+
+    context "#overwrite" do
+      it "should swap data with new content" do
+        new_event = LogStash::Event.new(
+            "type" => "new",
+            "message" => "foo bar",
+            )
+        subject.overwrite(new_event)
+
+        expect(subject.get("message")).to eq("foo bar")
+        expect(subject.get("type")).to eq("new")
+
+        ["tags", "source", "a", "c", "f", "j"].each do |field|
+          expect(subject.get(field)).to be_nil
+        end
+      end
+    end
+
+    it "should add key when setting nil value" do
+      subject.set("[baz]", nil)
+      expect(subject.to_hash).to include("baz" => nil)
+    end
+
+  end
+
+  let(:event_hash) do
+    {
+        "@timestamp" => "2013-01-01T00:00:00.000Z",
+        "type" => "sprintf",
+        "message" => "hello world",
+        "tags" => [ "tag1" ],
+        "source" => "/home/foo",
+        "a" => "b",
+        "c" => {
+            "d" => "f",
+            "e" => {"f" => "g"}
+        },
+        "f" => { "g" => { "h" => "i" } },
+        "j" => {
+            "k1" => "v",
+            "k2" => [ "w", "x" ],
+            "k3" => {"4" => "m"},
+            "k4" => [ {"nested" => "cool"} ],
+            5 => 6,
+            "5" => 7
+        },
+        "nilfield" => nil,
+        "@metadata" => { "fancy" => "pants", "have-to-go" => { "deeper" => "inception" } }
+    }
+  end
+
+  describe "no target" do
+    it_behaves_like 'namespace-able event' do
+      subject { wrap LogStash::Event.new(event_hash) }
+    end
+
+    it_behaves_like 'plain old event' do
+      subject { wrap LogStash::Event.new(event_hash) }
+    end
+  end
+
+  describe "sample target" do
+    let(:target) { 'sample' }
+    let(:decorator) do
+      event = new_event_from_hash(event_hash, target)
+      wrap(event, target)
+    end
+
+    subject { decorator }
+
+    it_behaves_like 'namespace-able event'
+
+    it "should add key when setting nil value" do
+      subject.set("[baz]", nil)
+      expect(subject.to_hash[target]).to include("baz" => nil)
+    end
+  end
+
+  describe "[sample][nested] target" do
+    let(:target) { '[sample][nested]' }
+    let(:decorator) do
+      event = new_event_from_hash(event_hash, target)
+      wrap(event, target)
+    end
+
+    subject { decorator }
+
+    it_behaves_like 'namespace-able event'
+
+    it "should add key when setting nil value" do
+      subject.set("[baz]", nil)
+      expect(subject.to_hash['sample']['nested']).to include("baz" => nil)
+    end
+  end
+
+  private
+
+  def new_event_from_hash(event_hash, target)
+    init_hash = event_hash.select { |key, _| key.start_with?('@') }
+    event = LogStash::Event.new(init_hash)
+    target = target.split(/\[(.*)\]/).join
+    event_hash.slice(*(event_hash.keys - init_hash.keys)).each do |key, val|
+      event.set("[#{target}][#{key}]", val)
+    end
+    event
+  end
+
+  def wrap(event, target_namespace = nil)
+    LogStash::PluginMixins::EventSupport::EventTargetDecorator.wrap(event, target_namespace)
+  end
+
+end

--- a/spec/logstash/spec_helper.rb
+++ b/spec/logstash/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'rspec'
+
+require "logstash-core"
+
+require "logstash/plugin_mixins/event_support/event_target_decorator"


### PR DESCRIPTION
Most of this came out from trying to move a few codecs to use an optional `target` namespace.
Not really anything to be put stone as this is WiP.

What I am looking for here is some general feedback whether to proceed from here or we'll want to do some parts different.

Tried taking into consideration the conversation from https://github.com/logstash-plugins/logstash-codec-cef/pull/80


Sample usage of codec plugins that have slightly different ways of creating events : 
- https://github.com/logstash-plugins/logstash-codec-cef/pull/80/files
- https://github.com/logstash-plugins/logstash-codec-json/pull/37/files
- https://github.com/logstash-plugins/logstash-codec-csv/pull/7/files



*Note: specs are just a start (copy-adjusted from LS) for the decorator class, ignore them for now ...*