### PR TITLE
Fix: compatibility when parsing blank JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.1
+  - Fix: compatibility when parsing blank JSON [#3](https://github.com/logstash-plugins/logstash-mixin-event_support/pull/3)
+
+## 1.0.0
+  - Feat: event factory support + from_json helper [#2](https://github.com/logstash-plugins/logstash-mixin-event_support/pull/2)

--- a/lib/logstash/plugin_mixins/event_support/from_json_helper.rb
+++ b/lib/logstash/plugin_mixins/event_support/from_json_helper.rb
@@ -36,6 +36,7 @@ module LogStash
             case decoded
             when Array then decoded.map { |data| event_factory.new_event(data) }
             when Hash  then [ event_factory.new_event(decoded) ]
+            when nil   then [] # same behavior as Event.from_json("")
             else raise LogStash::Json::ParserError.new("JSON must contain array or hash, got #{decoded.class}")
             end
           end

--- a/logstash-mixin-event_support.gemspec
+++ b/logstash-mixin-event_support.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-event_support'
-  s.version       = '1.0.0'
+  s.version       = '1.0.1'
   s.licenses      = %w(Apache-2.0)
   s.summary       = "Event support for Logstash plugins"
   s.authors       = %w(Elastic)

--- a/spec/logstash/plugin_mixins/event_support/from_json_helper_spec.rb
+++ b/spec/logstash/plugin_mixins/event_support/from_json_helper_spec.rb
@@ -51,6 +51,15 @@ describe LogStash::PluginMixins::EventSupport::FromJsonHelper do
           expect( events[1].get('[test]') ).to eql 'baz' => 42.0
         end
 
+        it 'does not raise on blank strings' do
+          events = plugin.events_from_json('', event_factory)
+          expect( events.size ).to eql 0
+          events = plugin.events_from_json("  ", event_factory)
+          expect( events.size ).to eql 0
+          events = plugin.events_from_json("\n", event_factory)
+          expect( events.size ).to eql 0
+        end
+
         it 'raises on unexpected json' do
           expect { plugin.events_from_json(' "42" ', event_factory) }.to raise_error(LogStash::Json::ParserError)
         end


### PR DESCRIPTION
We failed to parse JSON into events when a blank string is passed into `events_from_json(json)`.

The [`events_from_json`](https://github.com/logstash-plugins/logstash-mixin-event_support/blob/v1.0.0/lib/logstash/plugin_mixins/event_support/from_json_helper.rb#L34) facade provides `LS::Event.from_json(json) { with block }` in a backwards compatible way.
The code did not account for handling `""` and others the same way as `Event.from_json(json)` does (returns an empty `[]`).

This means json codec(s) will not behave the same on LS <= 7.13 vs (to be released) 7.14 when updated to latest codec versions. The PR resolves the discrepancy.